### PR TITLE
error is weird saying the number should be a string...  

### DIFF
--- a/manifests/configure.pp
+++ b/manifests/configure.pp
@@ -9,7 +9,7 @@ class fail2ban::configure (
 		ensure => present,
 		owner  => "root",
 		group  => "root",
-		mode   => 640,
+		mode   => "640",
 		content => template('fail2ban/jail.local.erb'),
 	}
 


### PR DESCRIPTION
Error: Parameter mode failed on File[/etc/fail2ban/jail.local]: The file mode specification must be a string, not 'Integer' (file: /tmp/vagrant-puppet/modules-338bb75473972d9ec9aa1430e33a575b/fail2ban/manifests/configure.pp, line: 8)